### PR TITLE
FFVII mode: equip Houdini Jacket and Wedding Ring

### DIFF
--- a/landing_page/ffvii/manifest.js
+++ b/landing_page/ffvii/manifest.js
@@ -14,8 +14,8 @@ var FF7_MANIFEST = {
     ],
     equipment: [
       { slot: 'Wpn.', name: 'Keyboard', desc: 'Standard-issue software developer weapon.' },
-      { slot: 'Arm.', name: 'Law degree', desc: 'Former lawyer. Grants resistance to fine print.' },
-      { slot: 'Acc.', name: 'Boulder, CO', desc: 'Currently equipped home base in Colorado.' }
+      { slot: 'Arm.', name: 'Houdini Jacket', desc: 'Escape-artist armor. No bind can hold him.' },
+      { slot: 'Acc.', name: 'Wedding Ring', desc: 'Bonded accessory. Cannot be unequipped.' }
     ],
     materia: [
       { name: 'Writing', color: 'green', href: '#/writing', hint: "Read Jesse's writing." },


### PR DESCRIPTION
## Why

Equipment update requested by Jesse: the armor and accessory slots get personal items instead of the law degree / location (Boulder still shows in the main screen's location window).

## What

- `Arm.` Law degree → **Houdini Jacket** — hint: 'Escape-artist armor. No bind can hold him.'
- `Acc.` Boulder, CO → **Wedding Ring** — hint: 'Bonded accessory. Cannot be unequipped.'

Data-only change in `manifest.js`.

## Verification (playwright, localhost)

- [x] Equip screen lists Keyboard / Houdini Jacket / Wedding Ring; hint bar shows each new description on hover
- [x] No page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)