### PR TITLE
Update Houdini Jacket description on FFVII page

### DIFF
--- a/landing_page/ffvii/manifest.js
+++ b/landing_page/ffvii/manifest.js
@@ -14,7 +14,7 @@ var FF7_MANIFEST = {
     ],
     equipment: [
       { slot: 'Wpn.', name: 'Keyboard', desc: 'Standard-issue software developer weapon.' },
-      { slot: 'Arm.', name: 'Houdini Jacket', desc: 'Escape-artist armor. No bind can hold him.' },
+      { slot: 'Arm.', name: 'Houdini Jacket', desc: 'Pattagucci baby' },
       { slot: 'Acc.', name: 'Wedding Ring', desc: 'Bonded accessory. Cannot be unequipped.' }
     ],
     materia: [


### PR DESCRIPTION
Updates the Houdini Jacket equipment description on the FFVII landing page.

- **Before:** "Escape-artist armor. No bind can hold him."
- **After:** "Pattagucci baby"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AErMFox5Y4c85EQyoQkLxQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AErMFox5Y4c85EQyoQkLxQ)_