### PR TITLE
Replace Futura font with MessySharpie custom font

### DIFF
--- a/landing_page/style.css
+++ b/landing_page/style.css
@@ -1,3 +1,9 @@
+@font-face {
+  font-family: 'MessySharpie';
+  src: url('https://cdn.jsdelivr.net/gh/jesselumarie/messy-sharpie@main/MessySharpie.woff2') format('woff2');
+  font-display: swap;
+}
+
 :root {
   --background-color: white;
   --main-color: #011035;
@@ -25,7 +31,7 @@
 html, body {
   background-color: white;
   background-color: var(--background-color);
-  font-family: 'Futura', 'Open Sans';
+  font-family: 'MessySharpie', 'Open Sans';
   margin: 0;
   padding: 0;
   text-align:center;

--- a/landing_page/style.css
+++ b/landing_page/style.css
@@ -167,6 +167,16 @@ a:hover {
   position: absolute;
 }
 
+/* MessySharpie's glyphs run wider than Futura's: cap the monogram size and
+   drop the max-width box so the letters fit inside the circle. The font draws
+   its caps ~0.06em below the em-box center, so nudge up to optically center. */
+.bigCircle-front {
+  font-size: 6rem;
+  line-height: 1;
+  max-width: none;
+  transform: translateY(-0.06em);
+}
+
 .bigCircle-back {
   font-size: 5rem;
   transform: rotateY(180deg);
@@ -309,6 +319,15 @@ span.wave {
   .bigCircle-back {
     font-size: 2rem;
     transform: rotateY(180deg);
+  }
+
+  /* keep the monogram at the same ~0.64x-of-circle ratio as desktop, and
+     re-apply the optical nudge the rule above resets via translate3d */
+  .bigCircle-front {
+    font-size: 10vw;
+    line-height: 1;
+    max-width: none;
+    transform: translateY(-0.06em);
   }
 
   .smallCircle {

--- a/landing_page/style.css
+++ b/landing_page/style.css
@@ -321,10 +321,11 @@ span.wave {
     transform: rotateY(180deg);
   }
 
-  /* keep the monogram at the same ~0.64x-of-circle ratio as desktop, and
-     re-apply the optical nudge the rule above resets via translate3d */
+  /* size the monogram to the 16vw circle with a bit more breathing room
+     than desktop, and re-apply the optical nudge the rule above resets
+     via translate3d */
   .bigCircle-front {
-    font-size: 10vw;
+    font-size: 8.5vw;
     line-height: 1;
     max-width: none;
     transform: translateY(-0.06em);

--- a/pelican_theme/static/css/main.css
+++ b/pelican_theme/static/css/main.css
@@ -4,6 +4,12 @@
 @import url("pygment.css");
 @import url("typogrify.css");
 
+@font-face {
+  font-family: 'MessySharpie';
+  src: url('https://cdn.jsdelivr.net/gh/jesselumarie/messy-sharpie@main/MessySharpie.woff2') format('woff2');
+  font-display: swap;
+}
+
 :root {
   --background-color: whitesmoke;
   --page-background: #3c3c3e;
@@ -39,7 +45,7 @@ html {
 body {
     color: #333333;
     font-size: 87.5%; /* Base font size: 14px */
-    font-family: 'Futura', 'Open Sans', sans-serif;
+    font-family: 'MessySharpie', 'Open Sans', sans-serif;
     line-height: 1.429;
     margin: 0;
     padding: 0;
@@ -204,12 +210,12 @@ body {
   font-weight:normal;
   font-size:14px;
   text-decoration:none;
-    font-family: 'Futura', 'Open Sans', sans-serif;
+    font-family: 'MessySharpie', 'Open Sans', sans-serif;
 }
 
 .tags_text{
   font-size: 16px;
-  font-family: 'Futura','Open Sans', sans-serif;
+  font-family: 'MessySharpie','Open Sans', sans-serif;
   font-weight:bold;
 }
 
@@ -244,7 +250,7 @@ h6 {font-size: 1.6em}		/* 14px */
 h1, h2, h3, h4, h5, h6 {
   line-height: 1.1;
   margin-bottom: .8em;
-    font-family: 'Futura',sans-serif;
+    font-family: 'MessySharpie',sans-serif;
 }
 
 h3, h4, h5, h6 { margin-top: .8em; }


### PR DESCRIPTION
## Summary
This PR replaces the Futura font with a custom MessySharpie font across the landing page and Pelican theme. The MessySharpie font is loaded from a CDN and includes specific styling adjustments to account for its different glyph metrics.

## Key Changes
- Added `@font-face` declaration to load MessySharpie font from CDN (jsdelivr) in both `landing_page/style.css` and `pelican_theme/static/css/main.css`
- Updated all font-family declarations from `'Futura'` to `'MessySharpie'` as the primary font choice
- Added specific styling rules for `.bigCircle-front` monogram element to accommodate MessySharpie's wider glyphs:
  - Capped font size to 6rem (desktop) and 8.5vw (mobile)
  - Removed max-width constraint to allow letters to fit inside the circle
  - Applied optical centering adjustment (`translateY(-0.06em)`) to account for MessySharpie's baseline positioning
- Added explanatory comments documenting the font metric adjustments

## Implementation Details
- Font is loaded with `font-display: swap` for better performance and fallback handling
- The MessySharpie font draws its capital letters approximately 0.06em below the em-box center, requiring a vertical translation for optical centering
- Mobile responsive styling maintains the optical adjustments while scaling the monogram to 8.5vw to fit the 16vw circle
- Fallback font chain preserved: MessySharpie → Open Sans → sans-serif

https://claude.ai/code/session_0126UrZDLDzGC6a7DGej5YfP