### PR TITLE
Center the JL monogram in the blog sidebar circle

### DIFF
--- a/pelican_theme/static/css/main.css
+++ b/pelican_theme/static/css/main.css
@@ -86,9 +86,13 @@ body {
   font-size: 4rem;
 }
 
+/* MessySharpie runs wider than Futura and draws its caps ~0.06em below the
+   em-box center: let the monogram out of the max-width box and nudge it up
+   so it sits optically centered in the circle */
 .bigCircle-inner {
   color: white;
-  max-width: 50%;
+  line-height: 1;
+  transform: translateY(-0.06em);
 }
 
 .smallCircle {
@@ -594,7 +598,7 @@ li:last-child .hentry, #content > .hentry {border: 0; margin: 0;}
   .bigCircle {
     width: 100px;
     height: 100px;
-    font-size: 4rem;
+    font-size: 3.5rem;
   }
 
   .smallCircle {


### PR DESCRIPTION
Follow-up to #17: applies the same MessySharpie centering fix to the blog's Pelican theme.

- `.bigCircle-inner` loses its `max-width: 50%` box (which pushed the wide MessySharpie glyphs off to the right), gets `line-height: 1`, and the same `translateY(-0.06em)` optical nudge to compensate for the font's low-sitting caps.
- The mobile topbar monogram drops from `4rem` to `3.5rem`, matching the ~80% circle-fill ratio used on the landing page.

Verified with headless-browser screenshots of the rebuilt Pelican site at desktop and iPhone widths, in light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126UrZDLDzGC6a7DGej5YfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0126UrZDLDzGC6a7DGej5YfP)_